### PR TITLE
Fix circular dependency between networking and firewall modules

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -290,15 +290,8 @@ resource "azurerm_route_table" "dev" {
   disable_bgp_route_propagation = false
 }
 
-# Route for internet-bound traffic from Dev (goes through firewall)
-resource "azurerm_route" "dev_to_internet" {
-  name                   = "route-dev-to-internet"
-  resource_group_name    = var.resource_group_dev
-  route_table_name       = azurerm_route_table.dev.name
-  address_prefix         = "0.0.0.0/0"
-  next_hop_type          = "VirtualAppliance"
-  next_hop_in_ip_address = var.firewall_private_ip
-}
+# Route for internet-bound traffic from Dev will be created in root main.tf
+# to avoid circular dependency between networking and firewall modules
 
 # Associate route table with Dev AKS subnet
 resource "azurerm_subnet_route_table_association" "dev_aks" {
@@ -316,15 +309,8 @@ resource "azurerm_route_table" "prod" {
   disable_bgp_route_propagation = false
 }
 
-# Route for internet-bound traffic from Prod (goes through firewall)
-resource "azurerm_route" "prod_to_internet" {
-  name                   = "route-prod-to-internet"
-  resource_group_name    = var.resource_group_prod
-  route_table_name       = azurerm_route_table.prod.name
-  address_prefix         = "0.0.0.0/0"
-  next_hop_type          = "VirtualAppliance"
-  next_hop_in_ip_address = var.firewall_private_ip
-}
+# Route for internet-bound traffic from Prod will be created in root main.tf
+# to avoid circular dependency between networking and firewall modules
 
 # Associate route table with Prod AKS subnet
 resource "azurerm_subnet_route_table_association" "prod_aks" {
@@ -342,15 +328,8 @@ resource "azurerm_route_table" "shared" {
   disable_bgp_route_propagation = false
 }
 
-# Route for internet-bound traffic from Shared (goes through firewall)
-resource "azurerm_route" "shared_to_internet" {
-  name                   = "route-shared-to-internet"
-  resource_group_name    = var.resource_group_shared
-  route_table_name       = azurerm_route_table.shared.name
-  address_prefix         = "0.0.0.0/0"
-  next_hop_type          = "VirtualAppliance"
-  next_hop_in_ip_address = var.firewall_private_ip
-}
+# Route for internet-bound traffic from Shared will be created in root main.tf
+# to avoid circular dependency between networking and firewall modules
 
 # Associate route table with Shared services subnet
 resource "azurerm_subnet_route_table_association" "shared_services" {

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -108,12 +108,27 @@ output "dev_route_table_id" {
   value       = azurerm_route_table.dev.id
 }
 
+output "dev_route_table_name" {
+  description = "Dev route table name"
+  value       = azurerm_route_table.dev.name
+}
+
 output "prod_route_table_id" {
   description = "Prod route table ID"
   value       = azurerm_route_table.prod.id
 }
 
+output "prod_route_table_name" {
+  description = "Prod route table name"
+  value       = azurerm_route_table.prod.name
+}
+
 output "shared_route_table_id" {
   description = "Shared route table ID"
   value       = azurerm_route_table.shared.id
+}
+
+output "shared_route_table_name" {
+  description = "Shared route table name"
+  value       = azurerm_route_table.shared.name
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -90,11 +90,6 @@ variable "shared_subnets" {
   type        = map(string)
 }
 
-variable "firewall_private_ip" {
-  description = "Azure Firewall private IP address"
-  type        = string
-}
-
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)


### PR DESCRIPTION
The circular dependency occurred because:
- Networking module created routes that needed the firewall's private IP
- Firewall module needed subnet IDs from the networking module
- This created: networking → firewall → networking (cycle)

Solution:
- Removed route resources (dev_to_internet, prod_to_internet, shared_to_internet) from networking module
- Kept route tables and associations in networking module
- Moved route resources to root main.tf after both modules are created
- Removed firewall_private_ip variable from networking module
- Added route table name outputs to networking module

This breaks the dependency cycle:
1. Networking module creates VNets, subnets, and route tables
2. Firewall module uses subnets and creates firewall
3. Root main.tf creates routes using firewall IP and route table names

Fixes: terraform validate cycle error