### PR TITLE
Fix deprecation warning and invalid resource type

### DIFF
--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -286,8 +286,8 @@ resource "azurerm_route_table" "dev" {
   resource_group_name = var.resource_group_dev
   tags                = var.tags
 
-  # Disable BGP route propagation (we control routes manually)
-  disable_bgp_route_propagation = false
+  # Enable BGP route propagation
+  bgp_route_propagation_enabled = true
 }
 
 # Route for internet-bound traffic from Dev will be created in root main.tf
@@ -306,7 +306,7 @@ resource "azurerm_route_table" "prod" {
   resource_group_name = var.resource_group_prod
   tags                = var.tags
 
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 }
 
 # Route for internet-bound traffic from Prod will be created in root main.tf
@@ -325,7 +325,7 @@ resource "azurerm_route_table" "shared" {
   resource_group_name = var.resource_group_shared
   tags                = var.tags
 
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = true
 }
 
 # Route for internet-bound traffic from Shared will be created in root main.tf

--- a/modules/shared-services/main.tf
+++ b/modules/shared-services/main.tf
@@ -39,11 +39,11 @@ resource "azurerm_container_registry" "main" {
 }
 
 # Geo-replication for ACR (Premium SKU only)
-resource "azurerm_container_registry_georeplications" "main" {
+resource "azurerm_container_registry_replication" "main" {
   count = var.enable_geo_replication && var.acr_sku == "Premium" ? 1 : 0
 
-  container_registry_name = azurerm_container_registry.main.name
-  resource_group_name     = var.resource_group_name
+  name                    = "northeurope"
+  container_registry_id   = azurerm_container_registry.main.id
   location                = "northeurope" # Replicate to another region
   zone_redundancy_enabled = true
   tags                    = var.tags


### PR DESCRIPTION
1. Route Tables - Fix Deprecation Warning:
   - Changed deprecated 'disable_bgp_route_propagation' to 'bgp_route_propagation_enabled'
   - Updated logic: disable_bgp_route_propagation = false → bgp_route_propagation_enabled = true
   - Applied to all three route tables (dev, prod, shared)
   - Locations: modules/networking/main.tf lines 290, 309, 328

2. ACR Geo-Replication - Fix Invalid Resource Type:
   - Changed: azurerm_container_registry_georeplications → azurerm_container_registry_replication
   - Updated attributes to match correct resource schema:
     * Added 'name' attribute (required)
     * Changed 'container_registry_name' + 'resource_group_name' → 'container_registry_id'
   - Location: modules/shared-services/main.tf line 42

These changes ensure compatibility with AzureRM provider v3.x and prepare for v4.0.

Fixes: terraform validate warnings and errors