### PR TITLE
Fix ACR geo-replication: Use nested block instead of separate resource

### DIFF
--- a/modules/shared-services/main.tf
+++ b/modules/shared-services/main.tf
@@ -35,18 +35,17 @@ resource "azurerm_container_registry" "main" {
     }
   }
 
+  # Geo-replication (only for Premium SKU)
+  dynamic "georeplications" {
+    for_each = var.enable_geo_replication && var.acr_sku == "Premium" ? [1] : []
+    content {
+      location                = "northeurope" # Replicate to North Europe
+      zone_redundancy_enabled = true
+      tags                    = var.tags
+    }
+  }
+
   tags = var.tags
-}
-
-# Geo-replication for ACR (Premium SKU only)
-resource "azurerm_container_registry_replication" "main" {
-  count = var.enable_geo_replication && var.acr_sku == "Premium" ? 1 : 0
-
-  name                    = "northeurope"
-  container_registry_id   = azurerm_container_registry.main.id
-  location                = "northeurope" # Replicate to another region
-  zone_redundancy_enabled = true
-  tags                    = var.tags
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The azurerm_container_registry_replication resource does not exist in AzureRM provider v3.x. Geo-replication must be configured as a nested block within the azurerm_container_registry resource.

Changes:
- Removed separate resource: azurerm_container_registry_replication
- Added dynamic "georeplications" block inside azurerm_container_registry resource
- Maintains same functionality: replicates to North Europe when enabled and Premium SKU
- Uses dynamic block to conditionally create geo-replication only when:
  * var.enable_geo_replication = true
  * var.acr_sku = "Premium"

Location: modules/shared-services/main.tf lines 38-46

Fixes: terraform validate error for invalid resource type