### PR TITLE
Fix AKS Azure AD deprecation and firewall diagnostic setting count error

### DIFF
--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -78,7 +78,6 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   # Azure RBAC for Kubernetes authorization
   azure_active_directory_role_based_access_control {
-    managed            = true
     azure_rbac_enabled = true # Use Azure RBAC instead of Kubernetes RBAC
   }
 

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -233,9 +233,10 @@ resource "azurerm_firewall" "main" {
 # DIAGNOSTIC SETTINGS (for logging)
 # -----------------------------------------------------------------------------
 # Sends firewall logs to Log Analytics for monitoring
+# Note: If enable_logs is true, log_analytics_workspace_id must be provided
 
 resource "azurerm_monitor_diagnostic_setting" "firewall" {
-  count = var.enable_logs && var.log_analytics_workspace_id != null ? 1 : 0
+  count = var.enable_logs ? 1 : 0
 
   name                       = "diag-${var.firewall_name}"
   target_resource_id         = azurerm_firewall.main.id


### PR DESCRIPTION
1. AKS Module - Remove Deprecated 'managed' Attribute:
   - Removed: managed = true from azure_active_directory_role_based_access_control block
   - Reason: This attribute is deprecated and will be removed in AzureRM provider v4.0
   - It will default to true, so explicit declaration is no longer needed
   - Location: modules/aks/main.tf line 81

2. Firewall Module - Fix Diagnostic Setting Count Dependency:
   - Changed: count = var.enable_logs && var.log_analytics_workspace_id != null ? 1 : 0
   - To: count = var.enable_logs ? 1 : 0
   - Reason: The workspace_id check depends on a conditionally created resource, which Terraform cannot determine at plan time, causing "Invalid count argument" error
   - Solution: Only check var.enable_logs flag; if enabled without workspace_id, it will fail with a clear error message
   - Added comment clarifying that workspace_id must be provided when enable_logs is true
   - Location: modules/firewall/main.tf line 238

These changes resolve the deprecation warning and the count dependency error, allowing terraform validate to pass successfully.

Fixes: terraform validate warnings and errors