### PR TITLE
Restore managed = true to AKS Azure AD RBAC configuration

### DIFF
--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -78,7 +78,8 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   # Azure RBAC for Kubernetes authorization
   azure_active_directory_role_based_access_control {
-    azure_rbac_enabled = true # Use Azure RBAC instead of Kubernetes RBAC
+    managed            = true  # Required in v3.x, will default to true in v4.0
+    azure_rbac_enabled = true  # Use Azure RBAC instead of Kubernetes RBAC
   }
 
   # Azure Policy add-on (enforces policies on the cluster)


### PR DESCRIPTION
The previous commit removed `managed = true` thinking it was optional due to the deprecation warning. However, in AzureRM provider v3.x, at least ONE of the azure_active_directory_role_based_access_control attributes must be specified:
- admin_group_object_ids
- client_app_id
- managed
- server_app_id
- server_app_secret
- tenant_id

Without any of these, terraform plan fails with "Missing required argument" errors.

Changes:
- Added back: managed = true
- Updated comment to clarify: "Required in v3.x, will default to true in v4.0"
- This resolves the validation error while maintaining AKS-managed Entra Integration

The deprecation warning will still appear, but it's informational only - the attribute is still required until AzureRM provider v4.0.

Location: modules/aks/main.tf line 81

Fixes: terraform plan "Missing required argument" errors for both aks_dev and aks_prod