### PR TITLE
Fix AKS managed identity permissions and firewall DNS proxy for Basic…

### DIFF
--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -41,9 +41,12 @@ resource "azurerm_firewall_policy" "main" {
   sku                 = var.firewall_sku_tier
   tags                = var.tags
 
-  # DNS settings
-  dns {
-    proxy_enabled = true # Enable DNS proxy
+  # DNS settings (only available in Standard and Premium SKU, not Basic)
+  dynamic "dns" {
+    for_each = var.firewall_sku_tier != "Basic" ? [1] : []
+    content {
+      proxy_enabled = true # Enable DNS proxy
+    }
   }
 
   # Threat intelligence (available in Standard and Premium)

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -62,6 +62,21 @@ resource "azurerm_role_assignment" "aks_prod_shared_reader" {
   principal_id         = azurerm_user_assigned_identity.aks_prod.principal_id
 }
 
+# Managed Identity Operator role for dev AKS on its own identity
+# This allows AKS control plane to assign the kubelet identity
+resource "azurerm_role_assignment" "aks_dev_mi_operator" {
+  scope                = azurerm_user_assigned_identity.aks_dev.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = azurerm_user_assigned_identity.aks_dev.principal_id
+}
+
+# Managed Identity Operator role for prod AKS on its own identity
+resource "azurerm_role_assignment" "aks_prod_mi_operator" {
+  scope                = azurerm_user_assigned_identity.aks_prod.id
+  role_definition_name = "Managed Identity Operator"
+  principal_id         = azurerm_user_assigned_identity.aks_prod.principal_id
+}
+
 # -----------------------------------------------------------------------------
 # DATA SOURCES
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
… SKU

This commit addresses two critical deployment errors:

1. AKS Managed Identity Operator Permission (CustomKubeletIdentityMissingPermissionError):
   - Added "Managed Identity Operator" role assignment for AKS control plane identities
   - Scope: The identity resource itself
   - This allows AKS to assign the kubelet identity during cluster creation
   - Applied to both dev and prod AKS identities
   - Location: modules/security/main.tf lines 65-78
   - Reference: https://learn.microsoft.com/en-us/azure/aks/use-managed-identity#add-role-assignment

2. Firewall DNS Proxy for Basic SKU (FirewallPolicyHigherTierOnlyProperties):
   - Changed DNS configuration from static block to dynamic block
   - DNS proxy and custom DNS are only available in Standard and Premium SKU
   - Now conditionally enabled: only when firewall_sku_tier != "Basic"
   - For Basic SKU: no DNS block is created
   - For Standard/Premium SKU: DNS proxy is enabled
   - Location: modules/firewall/main.tf lines 44-50

Note on deprecation warning:
The "managed = true" deprecation warning for AKS Azure AD integration will remain. This attribute is required in AzureRM provider v3.x and will be auto-defaulted in v4.0. The warning is informational only and does not affect deployment.

Fixes:
- CustomKubeletIdentityMissingPermissionError during AKS cluster creation
- FirewallPolicyHigherTierOnlyProperties error for Basic firewall SKU