### PR TITLE
Update Kubernetes version from 1.28 to 1.30 to avoid LTS-only restric…

### DIFF
--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -38,7 +38,7 @@ enable_firewall_logs = true
 # -----------------------------------------------------------------------------
 # AKS SETTINGS
 # -----------------------------------------------------------------------------
-aks_kubernetes_version = "1.28" # Update to latest stable version
+aks_kubernetes_version = "1.30" # Version 1.30 (1.28 is LTS-only and requires Premium tier)
 
 # Dev cluster settings (smaller for cost savings)
 dev_aks_node_count = 2                 # 2 nodes for dev

--- a/environments/prod/terraform.tfvars
+++ b/environments/prod/terraform.tfvars
@@ -39,7 +39,7 @@ enable_firewall_logs = true
 # -----------------------------------------------------------------------------
 # AKS SETTINGS
 # -----------------------------------------------------------------------------
-aks_kubernetes_version = "1.28" # Update to latest stable version
+aks_kubernetes_version = "1.30" # Version 1.30 (1.28 is LTS-only and requires Premium tier)
 
 # Dev cluster settings (not used in prod deployment, but required)
 dev_aks_node_count = 2

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -23,7 +23,7 @@ firewall_sku_tier    = "Basic" # Basic, Standard, or Premium
 enable_firewall_logs = true
 
 # AKS Settings
-aks_kubernetes_version = "1.28"
+aks_kubernetes_version = "1.30" # 1.28 is LTS-only (requires Premium tier)
 
 dev_aks_node_count = 2
 dev_aks_node_size  = "Standard_D2s_v3"

--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "enable_firewall_logs" {
 variable "aks_kubernetes_version" {
   description = "Kubernetes version for AKS clusters"
   type        = string
-  default     = "1.28" # Update this to latest stable version
+  default     = "1.30" # Using 1.30 as it's widely supported (1.28 is LTS-only)
 }
 
 variable "dev_aks_node_count" {


### PR DESCRIPTION
…tion

Issue:
AKS cluster creation was failing with error: "K8sVersionNotSupported" Kubernetes version 1.28.15 is now only available for Long-Term Support (LTS), which requires Premium tier and LTS support plan.

Since the configuration uses:
- Free tier for dev environment
- Standard tier for prod environment (not Premium)

Version 1.28 cannot be used without upgrading to Premium tier.

Solution:
Updated Kubernetes version from 1.28 to 1.30 across all configuration files. Version 1.30 is a supported non-LTS version that works with Free and Standard tiers.

Files Updated:
1. variables.tf - Changed default from "1.28" to "1.30"
2. environments/dev/terraform.tfvars - Updated to "1.30"
3. environments/prod/terraform.tfvars - Updated to "1.30"
4. terraform.tfvars.example - Updated to "1.30" for reference

All files now include clarifying comment:
"Version 1.30 (1.28 is LTS-only and requires Premium tier)"

References:
- https://aka.ms/aks/enable-lts
- https://aka.ms/supported-version-list

Fixes: K8sVersionNotSupported error during AKS cluster creation