### PR TITLE
Fix Azure authorization error for role assignments

### DIFF
--- a/PERMISSIONS.md
+++ b/PERMISSIONS.md
@@ -1,0 +1,269 @@
+# Azure RBAC Permissions for Terraform Deployment
+
+## Overview
+
+This document explains the Azure permissions required to deploy this infrastructure and how to resolve authorization errors related to role assignments.
+
+## The Authorization Error
+
+If you encounter this error during deployment:
+
+```
+Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=403
+Code="AuthorizationFailed"
+Message="The client with object id 'xxx' does not have authorization to perform action
+'Microsoft.Authorization/roleAssignments/write'"
+```
+
+This means the service principal or managed identity running Terraform doesn't have sufficient permissions to create role assignments.
+
+## Understanding Azure RBAC Roles
+
+Azure has built-in roles with different capabilities:
+
+- **Owner**: Full access including the ability to manage role assignments
+- **User Access Administrator**: Can manage role assignments but not resources
+- **Contributor**: Can manage resources but **CANNOT** create role assignments
+- **Reader**: Read-only access
+
+## Solutions
+
+### Option 1: Skip Role Assignments (Recommended for Limited Permissions)
+
+If you don't have permissions to create role assignments, you can skip them during deployment and create them manually later:
+
+1. **Set the variable to skip role assignments:**
+
+   Edit your `environments/dev/terraform.tfvars` or `environments/prod/terraform.tfvars`:
+
+   ```hcl
+   create_role_assignments = false
+   ```
+
+2. **Deploy with Terraform:**
+
+   ```bash
+   terraform apply -var-file=environments/dev/terraform.tfvars
+   ```
+
+3. **Manually create the role assignments after deployment** (see below)
+
+### Option 2: Grant Proper Permissions (Recommended for Production)
+
+Ask your Azure administrator to grant the service principal one of these roles:
+
+#### For Subscription-Level Deployment:
+
+```bash
+# Get your service principal ID
+SP_ID=$(az ad sp list --display-name "your-sp-name" --query "[0].id" -o tsv)
+
+# Option A: Grant User Access Administrator (can manage RBAC only)
+az role assignment create \
+  --assignee $SP_ID \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID"
+
+# Option B: Grant Owner (full access - use with caution)
+az role assignment create \
+  --assignee $SP_ID \
+  --role "Owner" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID"
+```
+
+#### For Resource Group-Level Deployment:
+
+```bash
+# Grant User Access Administrator on specific resource groups
+az role assignment create \
+  --assignee $SP_ID \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-dev"
+
+az role assignment create \
+  --assignee $SP_ID \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-prod"
+
+az role assignment create \
+  --assignee $SP_ID \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-shared"
+```
+
+### Option 3: Enable Role Assignments Later
+
+If you deployed with `create_role_assignments = false`, you can enable them later:
+
+1. **Grant the required permissions** (see Option 2 above)
+
+2. **Update your tfvars:**
+
+   ```hcl
+   create_role_assignments = true
+   ```
+
+3. **Apply the changes:**
+
+   ```bash
+   terraform apply -var-file=environments/dev/terraform.tfvars
+   ```
+
+## Manual Role Assignment Creation
+
+If you skip role assignments during Terraform deployment, create them manually:
+
+### 1. Get the Managed Identity Principal IDs
+
+```bash
+# Dev AKS Identity
+DEV_MI_ID=$(az identity show \
+  --name mi-hubspoke-dev-weu-aks-dev \
+  --resource-group rg-hubspoke-dev-weu-dev \
+  --query principalId -o tsv)
+
+# Prod AKS Identity
+PROD_MI_ID=$(az identity show \
+  --name mi-hubspoke-dev-weu-aks-prod \
+  --resource-group rg-hubspoke-dev-weu-prod \
+  --query principalId -o tsv)
+```
+
+### 2. Create Role Assignments
+
+```bash
+# Network Contributor for Dev AKS
+az role assignment create \
+  --assignee $DEV_MI_ID \
+  --role "Network Contributor" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-dev"
+
+# Network Contributor for Prod AKS
+az role assignment create \
+  --assignee $PROD_MI_ID \
+  --role "Network Contributor" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-prod"
+
+# Reader on Shared Services for Dev AKS
+az role assignment create \
+  --assignee $DEV_MI_ID \
+  --role "Reader" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-shared"
+
+# Reader on Shared Services for Prod AKS
+az role assignment create \
+  --assignee $PROD_MI_ID \
+  --role "Reader" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/rg-hubspoke-dev-weu-shared"
+
+# Managed Identity Operator for Dev AKS (on its own identity)
+DEV_MI_RESOURCE_ID=$(az identity show \
+  --name mi-hubspoke-dev-weu-aks-dev \
+  --resource-group rg-hubspoke-dev-weu-dev \
+  --query id -o tsv)
+
+az role assignment create \
+  --assignee $DEV_MI_ID \
+  --role "Managed Identity Operator" \
+  --scope "$DEV_MI_RESOURCE_ID"
+
+# Managed Identity Operator for Prod AKS (on its own identity)
+PROD_MI_RESOURCE_ID=$(az identity show \
+  --name mi-hubspoke-dev-weu-aks-prod \
+  --resource-group rg-hubspoke-dev-weu-prod \
+  --query id -o tsv)
+
+az role assignment create \
+  --assignee $PROD_MI_ID \
+  --role "Managed Identity Operator" \
+  --scope "$PROD_MI_RESOURCE_ID"
+```
+
+## Role Assignments Explained
+
+The security module creates these role assignments:
+
+| Role | Identity | Scope | Purpose |
+|------|----------|-------|---------|
+| Network Contributor | Dev AKS MI | Dev Resource Group | Allows AKS to manage network resources (load balancers, IPs) |
+| Network Contributor | Prod AKS MI | Prod Resource Group | Allows AKS to manage network resources |
+| Reader | Dev AKS MI | Shared Resource Group | Allows Dev AKS to read shared services metadata |
+| Reader | Prod AKS MI | Shared Resource Group | Allows Prod AKS to read shared services metadata |
+| Managed Identity Operator | Dev AKS MI | Dev AKS MI | Allows AKS control plane to assign kubelet identity |
+| Managed Identity Operator | Prod AKS MI | Prod AKS MI | Allows AKS control plane to assign kubelet identity |
+
+## For CI/CD Pipelines
+
+When using GitHub Actions or Azure DevOps:
+
+### GitHub Actions with OIDC
+
+Ensure your Azure AD App Registration has the required role:
+
+```bash
+# Get the app ID
+APP_ID=$(az ad app list --display-name "github-oidc-app" --query "[0].appId" -o tsv)
+
+# Create service principal if needed
+SP_ID=$(az ad sp create --id $APP_ID --query id -o tsv)
+
+# Grant User Access Administrator
+az role assignment create \
+  --assignee $SP_ID \
+  --role "User Access Administrator" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID"
+```
+
+### Azure DevOps Service Connection
+
+1. Navigate to **Project Settings** → **Service connections**
+2. Edit your Azure Resource Manager connection
+3. Ask your admin to grant "User Access Administrator" role to the service principal
+4. Or set `create_role_assignments = false` in your pipeline variables
+
+## Troubleshooting
+
+### Check Current Permissions
+
+```bash
+# List role assignments for your service principal
+az role assignment list \
+  --assignee YOUR_SP_OBJECT_ID \
+  --all \
+  --output table
+```
+
+### Verify Service Principal Identity
+
+```bash
+# For Azure CLI login
+az account show
+
+# For service principal
+az ad sp show --id YOUR_SP_OBJECT_ID
+```
+
+### Test Permissions
+
+```bash
+# Test if you can create a role assignment
+az role assignment create \
+  --assignee YOUR_SP_OBJECT_ID \
+  --role "Reader" \
+  --scope "/subscriptions/YOUR_SUBSCRIPTION_ID/resourceGroups/test-rg" \
+  --dry-run
+```
+
+## Best Practices
+
+1. **Principle of Least Privilege**: Only grant "User Access Administrator" at the resource group level if possible
+2. **Separate Deployments**: Consider separating infrastructure deployment from role assignment creation
+3. **Audit Regularly**: Review role assignments periodically
+4. **Use Managed Identities**: Prefer managed identities over service principals when possible
+5. **Document Permissions**: Keep track of which identities have which permissions
+
+## References
+
+- [Azure built-in roles](https://docs.microsoft.com/azure/role-based-access-control/built-in-roles)
+- [Assign Azure roles using Azure CLI](https://docs.microsoft.com/azure/role-based-access-control/role-assignments-cli)
+- [Best practices for Azure RBAC](https://docs.microsoft.com/azure/role-based-access-control/best-practices)

--- a/README.md
+++ b/README.md
@@ -404,32 +404,44 @@ All resources follow Azure Cloud Adoption Framework naming:
 
 ### Common Issues
 
-**1. Terraform Init Fails**
+**1. Authorization/Permission Errors (Role Assignments)**
+
+If you see errors like:
+```
+Error: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=403
+Code="AuthorizationFailed"
+```
+
+This means your service principal doesn't have permission to create role assignments. **See [PERMISSIONS.md](PERMISSIONS.md) for detailed solutions.**
+
+Quick fix: Set `create_role_assignments = false` in your `terraform.tfvars` file.
+
+**2. Terraform Init Fails**
 ```bash
 # Clear cache and re-initialize
 rm -rf .terraform .terraform.lock.hcl
 terraform init
 ```
 
-**2. Authentication Errors**
+**3. Authentication Errors**
 ```bash
 # Re-login to Azure
 az login
 az account show
 ```
 
-**3. Quota Limits**
+**4. Quota Limits**
 ```bash
 # Check your quota
 az vm list-usage --location uksouth --output table
 ```
 
-**4. AKS Private Cluster Access**
+**5. AKS Private Cluster Access**
 - Private AKS clusters can only be accessed from within the VNet
 - Use Azure Bastion or VPN to access the cluster
 - Or use `az aks command invoke` for commands
 
-**5. Firewall Rules**
+**6. Firewall Rules**
 - If pods can't reach internet, check firewall rules
 - Review logs: Azure Portal → Firewall → Logs
 

--- a/main.tf
+++ b/main.tf
@@ -202,6 +202,9 @@ module "security" {
   mi_aks_dev_name  = local.mi_aks_dev_name
   mi_aks_prod_name = local.mi_aks_prod_name
 
+  # Role assignments
+  create_role_assignments = var.create_role_assignments
+
   # Tags
   tags = local.common_tags
 

--- a/modules/security/main.tf
+++ b/modules/security/main.tf
@@ -35,6 +35,7 @@ resource "azurerm_user_assigned_identity" "aks_prod" {
 # Network Contributor role for dev AKS on its resource group
 # This allows AKS to manage network resources
 resource "azurerm_role_assignment" "aks_dev_network" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_dev}"
   role_definition_name = "Network Contributor"
   principal_id         = azurerm_user_assigned_identity.aks_dev.principal_id
@@ -42,6 +43,7 @@ resource "azurerm_role_assignment" "aks_dev_network" {
 
 # Network Contributor role for prod AKS on its resource group
 resource "azurerm_role_assignment" "aks_prod_network" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_prod}"
   role_definition_name = "Network Contributor"
   principal_id         = azurerm_user_assigned_identity.aks_prod.principal_id
@@ -50,6 +52,7 @@ resource "azurerm_role_assignment" "aks_prod_network" {
 # Reader role on shared services resource group for dev AKS
 # This allows dev AKS to see (but not modify) shared services
 resource "azurerm_role_assignment" "aks_dev_shared_reader" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_shared}"
   role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.aks_dev.principal_id
@@ -57,6 +60,7 @@ resource "azurerm_role_assignment" "aks_dev_shared_reader" {
 
 # Reader role on shared services resource group for prod AKS
 resource "azurerm_role_assignment" "aks_prod_shared_reader" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_shared}"
   role_definition_name = "Reader"
   principal_id         = azurerm_user_assigned_identity.aks_prod.principal_id
@@ -65,6 +69,7 @@ resource "azurerm_role_assignment" "aks_prod_shared_reader" {
 # Managed Identity Operator role for dev AKS on its own identity
 # This allows AKS control plane to assign the kubelet identity
 resource "azurerm_role_assignment" "aks_dev_mi_operator" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = azurerm_user_assigned_identity.aks_dev.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = azurerm_user_assigned_identity.aks_dev.principal_id
@@ -72,6 +77,7 @@ resource "azurerm_role_assignment" "aks_dev_mi_operator" {
 
 # Managed Identity Operator role for prod AKS on its own identity
 resource "azurerm_role_assignment" "aks_prod_mi_operator" {
+  count                = var.create_role_assignments ? 1 : 0
   scope                = azurerm_user_assigned_identity.aks_prod.id
   role_definition_name = "Managed Identity Operator"
   principal_id         = azurerm_user_assigned_identity.aks_prod.principal_id

--- a/modules/security/variables.tf
+++ b/modules/security/variables.tf
@@ -41,3 +41,9 @@ variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)
 }
+
+variable "create_role_assignments" {
+  description = "Create RBAC role assignments for managed identities. Set to false if the service principal doesn't have User Access Administrator permissions"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -205,3 +205,13 @@ variable "log_retention_days" {
   type        = number
   default     = 30
 }
+
+# -----------------------------------------------------------------------------
+# SECURITY
+# -----------------------------------------------------------------------------
+
+variable "create_role_assignments" {
+  description = "Create RBAC role assignments for managed identities. Set to false if the service principal doesn't have User Access Administrator or Owner permissions"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Added conditional role assignment creation to handle cases where the service principal doesn't have User Access Administrator permissions.

Changes:
- Added 'create_role_assignments' variable (default: false) to skip role assignments when permissions are insufficient
- Updated all 6 role assignment resources in security module to be conditional based on the new variable
- Created comprehensive PERMISSIONS.md documentation explaining the error, solutions, and how to manually create role assignments
- Updated README.md troubleshooting section with quick reference

This allows deployment to proceed even when the service principal only has Contributor role, with role assignments being created manually or after proper permissions are granted.

Resolves AuthorizationFailed errors when creating role assignments.